### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ conf/logger.json
 logger.json
 csp.log
 TODO.txt
+yarn.lock


### PR DESCRIPTION
For those of us who use [Yarn](https://yarnpkg.com/), would be nice to have the lock file in `.gitignore`.